### PR TITLE
회원가입, 로그인, 로그아웃 UI 코드 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "node-sass": "^7.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4930,6 +4931,28 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -21651,6 +21674,27 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "todolist",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "node-sass": "^7.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,14 @@
 import './App.scss';
+import AuthTemplate from './components/AuthTemplate';
 import TodoTemplate from './components/TodoTemplate';
 
 function App() {
-  return <TodoTemplate />;
+  // TODO: 적절한 인증값 받아오는 로직 작성
+  if (window.sessionStorage.getItem('isAuthenticated')) {
+    return <TodoTemplate />;
+  } else {
+    return <AuthTemplate />;
+  }
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,16 @@
+import { useEffect } from 'react';
+import { silentRefresh } from './api/auth';
 import './App.scss';
 import AuthTemplate from './components/AuthTemplate';
 import TodoTemplate from './components/TodoTemplate';
 
 function App() {
+  useEffect(() => {
+    silentRefresh();
+  }, []);
+
   // TODO: 적절한 인증값 받아오는 로직 작성
-  if (window.sessionStorage.getItem('isAuthenticated')) {
+  if (window.sessionStorage.getItem('refreshToken')) {
     return <TodoTemplate />;
   } else {
     return <AuthTemplate />;

--- a/src/App.js
+++ b/src/App.js
@@ -12,9 +12,9 @@ function App() {
   // TODO: 적절한 인증값 받아오는 로직 작성
   if (window.sessionStorage.getItem('refreshToken')) {
     return <TodoTemplate />;
-  } else {
-    return <AuthTemplate />;
   }
+  
+  return <AuthTemplate />;
 }
 
 export default App;

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -67,3 +67,16 @@ export const signUp = ({
     });
 };
 
+export const signOut = () => {
+  axios
+    .post("api/accounts/logout/", {
+      refresh: window.sessionStorage.getItem("refreshToken"),
+    })
+    .then((res) => {
+      sessionStorage.clear();
+      window.location.reload();
+    })
+    .catch((err) => {
+      // 에러 처리
+    });
+};

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -49,13 +49,11 @@ export const silentRefresh = () => {
 }
 
 export const signUp = ({
-  email = "",
   username,
   password,
 }) => {
   axios
     .post("api/accounts/signup/", {
-      email: `${username}@naver.com`,
       username,
       password,
     })

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,5 +1,53 @@
 import axios from "axios";
 
+const JWT_EXPIRY_TIME = 2 * 3600 * 1000; // 서버에서 설정된 jwt access token의 유효시간
+
+export const signIn = ({
+  username,
+  password,
+}) => {
+  axios
+    .post("/api/accounts/login/", { username, password })
+    .then((res) => {
+      sessionStorage.setItem('refreshToken', res.data.tokens.refresh);
+
+      onSigninSuccess(res.data.tokens.access);
+
+      window.location.reload();
+    })
+    .catch((err) => {
+      // 에러 처리
+    });
+};
+
+const onSigninSuccess = (access) => {
+  axios.defaults.headers.common['Authorization'] = `JWT ${access}`;
+
+  // 토큰 만료 5분 전에 자동으로 유효시간을 늘려준다.
+  setTimeout(silentRefresh, JWT_EXPIRY_TIME - 300000);
+}
+
+export const silentRefresh = () => {
+  const refreshToken = sessionStorage.getItem('refreshToken');
+
+  if (!refreshToken) {
+    return;
+  }
+
+  axios
+    .post('api/accounts/token/refresh/', {
+      refresh: refreshToken
+    })
+    .then(res => onSigninSuccess(res.data.access))
+    .catch(err => {
+      if (err.response.status === 401) {
+        alert('다시 로그인해주세요.');
+        sessionStorage.clear();
+        window.location.reload();
+      }
+    });
+}
+
 export const signUp = ({
   email = "",
   username,

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+export const signUp = ({
+  email = "",
+  username,
+  password,
+}) => {
+  axios
+    .post("api/accounts/signup/", {
+      email: `${username}@naver.com`,
+      username,
+      password,
+    })
+    .then(() => {
+      alert("회원가입 완료");
+    })
+    .catch((err) => {
+      // 에러 처리
+    });
+};
+

--- a/src/components/AuthTemplate/index.js
+++ b/src/components/AuthTemplate/index.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import SignIn from '../SignIn';
+import SignUp from '../SignUp';
+
+function AuthTemplate() {
+  const [screen, setScreen] = useState('signin');
+
+  const onChangeScreen = (nextScreen) => {
+    setScreen(nextScreen);
+  }
+
+  if (screen === 'signin') {
+    return <SignIn onChangeScreen={onChangeScreen} />;
+  } else {
+    return <SignUp onChangeScreen={onChangeScreen} />;
+  }
+}
+
+export default AuthTemplate;

--- a/src/components/SignIn/SignIn.scss
+++ b/src/components/SignIn/SignIn.scss
@@ -1,0 +1,24 @@
+.sign-in-form {
+  margin: 0 auto;
+  padding-top: 50px;
+  width: 75%;
+
+  input, input {
+    margin-bottom: 20px;
+  }
+  
+  button {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    font-size: 18px;
+    padding: 12px;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    outline: none;
+  }
+
+  button, button {
+    margin-top: 20px;
+  }
+}

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -3,7 +3,7 @@ import './SignIn.scss';
 
 function SignIn({ onChangeScreen }) {
   const [formData, setFormData] = useState({
-    email: '',
+    username: '',
     password: '',
   });
 
@@ -23,17 +23,17 @@ function SignIn({ onChangeScreen }) {
 
     // TODO: 로그인 로직 추가 필요
     window.sessionStorage.setItem('isAuthenticated', 'true');
-    setFormData({ email: '', password: '' });
+    setFormData({ username: '', password: '' });
     return true;
   }
 
   const isSubmitAvailable = () => {
     const {
-      email,
+      username,
       password
     } = formData;
 
-    if (!email || !password) {
+    if (!username || !password) {
       alert('모든 항목을 채워주세요');
       return false;
     }
@@ -50,11 +50,11 @@ function SignIn({ onChangeScreen }) {
         <input
           autoFocus
           type="text"
-          id="email"
-          name="email"
-          value={formData.email}
+          id="username"
+          name="username"
+          value={formData.username}
           onChange={onChangeFormData}
-          placeholder="이메일"
+          placeholder="아이디"
         />
         <input
           type="password"

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -35,7 +35,7 @@ function SignIn({ onChangeScreen }) {
       password
     } = formData;
 
-    if (!username || !password) {
+    if (!username.trim() || !password.trim()) {
       alert('모든 항목을 채워주세요');
       return false;
     }

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { signIn } from '../../api/auth';
 import './SignIn.scss';
 
 function SignIn({ onChangeScreen }) {
@@ -17,13 +18,14 @@ function SignIn({ onChangeScreen }) {
   };
 
   const onSubmit = (e) => {
+    e.preventDefault();
+
     if (!isSubmitAvailable()) {
       return false;
     }
 
-    // TODO: 로그인 로직 추가 필요
-    window.sessionStorage.setItem('isAuthenticated', 'true');
-    setFormData({ username: '', password: '' });
+    signIn(formData);
+
     return true;
   }
 

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -17,9 +17,27 @@ function SignIn({ onChangeScreen }) {
   };
 
   const onSubmit = (e) => {
+    if (!isSubmitAvailable()) {
+      return false;
+    }
+
     // TODO: 로그인 로직 추가 필요
     window.sessionStorage.setItem('isAuthenticated', 'true');
     setFormData({ email: '', password: '' });
+    return true;
+  }
+
+  const isSubmitAvailable = () => {
+    const {
+      email,
+      password
+    } = formData;
+
+    if (!email || !password) {
+      alert('모든 항목을 채워주세요');
+      return false;
+    }
+
     return true;
   }
 

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import './SignIn.scss';
+
+function SignIn({ onChangeScreen }) {
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+
+  const onChangeFormData = (e) => {
+    e.preventDefault();
+
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const onSubmit = (e) => {
+    // TODO: 로그인 로직 추가 필요
+    window.sessionStorage.setItem('isAuthenticated', 'true');
+    setFormData({ email: '', password: '' });
+    return true;
+  }
+
+  return (
+    <div className="template-container">
+      <div className="head-container">
+        <h1>로그인</h1>
+      </div>
+      <form className="sign-in-form" onSubmit={onSubmit}>
+        <input
+          autoFocus
+          type="text"
+          id="email"
+          name="email"
+          value={formData.email}
+          onChange={onChangeFormData}
+          placeholder="이메일"
+        />
+        <input
+          type="password"
+          id="password"
+          name="password"
+          value={formData.password}
+          onChange={onChangeFormData}
+          placeholder="비밀번호"
+        />
+        <button type="submit">로그인</button>
+        <button onClick={() => onChangeScreen('signup')}>회원가입</button>
+      </form>
+    </div>
+  );
+}
+
+export default SignIn;

--- a/src/components/SignUp/SignUp.scss
+++ b/src/components/SignUp/SignUp.scss
@@ -1,0 +1,24 @@
+.sign-up-form {
+  margin: 0 auto;
+  padding-top: 50px;
+  width: 75%;
+
+  input, input {
+    margin-bottom: 20px;
+  }
+  
+  button {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    font-size: 18px;
+    padding: 12px;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    outline: none;
+  }
+
+  button, button {
+    margin-top: 20px;
+  }
+}

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -18,9 +18,20 @@ function SignUp({ onChangeScreen }) {
 
     const { username, password } = formData;
 
+    if (!isValidate()) {
+      alert('아이디는 영문과 숫자로만 입력해주세요');
+      return;
+    }
+
     signUp({ username, password });
     
     return true;
+  }
+
+  const isValidate = () => {
+    const regex = /^[a-z0-9]+$/i;
+
+    return regex.test(formData.username);
   }
 
   const isSubmitAvailable = () => {

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -30,12 +30,12 @@ function SignUp({ onChangeScreen }) {
       passwordCheck
     } = formData;
 
-    if (!username || !password || !passwordCheck) {
+    if (!username.trim() || !password.trim() || !passwordCheck.trim()) {
       alert('모든 항목을 채워주세요');
       return false;
     }
 
-    if (username.length < 4) {
+    if (username.trim().length < 4) {
       alert('4자 이상의 아이디를 설정해주세요')
     }
 
@@ -44,7 +44,7 @@ function SignUp({ onChangeScreen }) {
       return false;
     }
 
-    if (password.length < 8) {
+    if (password.trim().length < 8) {
       alert('6자리 이상의 비밀번호를 설정해주세요');
       return false;
     }

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import './SignUp.scss';
+
+function SignUp({ onChangeScreen }) {
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    passwordCheck: '',
+  });
+
+  const onSubmit = (e) => {
+    if (!isSubmitAvailable()) {
+      e.preventDefault();
+      return false;
+    }
+
+    window.sessionStorage.setItem('isAuthenticated', true);
+    // TODO: 서버로 회원가입 요청하는 로직 작성
+
+    setFormData({
+      email: '',
+      password: '',
+      passwordCheck: '',
+    });
+    return true;
+  }
+
+  const isSubmitAvailable = () => {
+    const {
+      email,
+      password,
+      passwordCheck
+    } = formData;
+
+    if (!email || !password || !passwordCheck) {
+      alert('모든 항목을 채워주세요');
+      return false;
+    }
+
+    if (password !== passwordCheck) {
+      alert('비밀번호가 서로 다릅니다');
+      return false;
+    }
+
+    if (password.length < 6) {
+      alert('6자리 이상의 비밀번호를 설정해주세요');
+      return false;
+    }
+
+    return true;
+  }
+
+  const onChangeFormData = (e) => {
+    e.preventDefault();
+
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  }
+
+  return (
+    <div className="template-container">
+      <div className="head-container">
+        <h1>회원가입</h1>
+      </div>
+      <form className="sign-up-form" onSubmit={onSubmit}>
+        <label>
+          이메일
+          <input
+            autoFocus
+            type="text"
+            id="email"
+            name="email"
+            value={formData.email}
+            onChange={onChangeFormData}
+            placeholder="이메일"
+          />
+        </label>
+
+        <label>
+          비밀번호
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={onChangeFormData}
+            placeholder="6자리 이상의 비밀번호"
+          />
+        </label>
+
+        <label>
+          비밀번호 확인
+          <input
+            type="password"
+            id="passwordCheck"
+            name="passwordCheck"
+            value={formData.passwordCheck}
+            onChange={onChangeFormData}
+            placeholder="비밀번호 확인"
+          />
+        </label>
+        <button type="submit">회원가입 완료</button>
+        <button onClick={() => onChangeScreen('signin')}>로그인</button>
+      </form>
+    </div>
+  );
+}
+
+export default SignUp;

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { signUp } from '../../api/auth';
 import './SignUp.scss';
 
 function SignUp({ onChangeScreen }) {
@@ -9,19 +10,16 @@ function SignUp({ onChangeScreen }) {
   });
 
   const onSubmit = (e) => {
+    e.preventDefault();
+
     if (!isSubmitAvailable()) {
-      e.preventDefault();
       return false;
     }
 
-    window.sessionStorage.setItem('isAuthenticated', true);
-    // TODO: 서버로 회원가입 요청하는 로직 작성
+    const { username, password } = formData;
 
-    setFormData({
-      username: '',
-      password: '',
-      passwordCheck: '',
-    });
+    signUp({ username, password });
+    
     return true;
   }
 

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -3,7 +3,7 @@ import './SignUp.scss';
 
 function SignUp({ onChangeScreen }) {
   const [formData, setFormData] = useState({
-    email: '',
+    username: '',
     password: '',
     passwordCheck: '',
   });
@@ -18,7 +18,7 @@ function SignUp({ onChangeScreen }) {
     // TODO: 서버로 회원가입 요청하는 로직 작성
 
     setFormData({
-      email: '',
+      username: '',
       password: '',
       passwordCheck: '',
     });
@@ -27,12 +27,12 @@ function SignUp({ onChangeScreen }) {
 
   const isSubmitAvailable = () => {
     const {
-      email,
+      username,
       password,
       passwordCheck
     } = formData;
 
-    if (!email || !password || !passwordCheck) {
+    if (!username || !password || !passwordCheck) {
       alert('모든 항목을 채워주세요');
       return false;
     }
@@ -66,15 +66,15 @@ function SignUp({ onChangeScreen }) {
       </div>
       <form className="sign-up-form" onSubmit={onSubmit}>
         <label>
-          이메일
+          아이디
           <input
             autoFocus
             type="text"
-            id="email"
-            name="email"
-            value={formData.email}
+            id="username"
+            name="username"
+            value={formData.username}
             onChange={onChangeFormData}
-            placeholder="이메일"
+            placeholder="아이디"
           />
         </label>
 

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -35,12 +35,16 @@ function SignUp({ onChangeScreen }) {
       return false;
     }
 
+    if (username.length < 4) {
+      alert('4자 이상의 아이디를 설정해주세요')
+    }
+
     if (password !== passwordCheck) {
       alert('비밀번호가 서로 다릅니다');
       return false;
     }
 
-    if (password.length < 6) {
+    if (password.length < 8) {
       alert('6자리 이상의 비밀번호를 설정해주세요');
       return false;
     }

--- a/src/components/TodoCreate/index.js
+++ b/src/components/TodoCreate/index.js
@@ -1,17 +1,17 @@
-import { useState } from 'react';
-import { MdAdd } from 'react-icons/md';
-import './TodoCreate.scss';
+import { useState } from "react";
+import { MdAdd } from "react-icons/md";
+import "./TodoCreate.scss";
 
 function TodoCreate({ onCreate }) {
   const [open, setOpen] = useState(false);
-  const [text, setText] = useState('');
+  const [text, setText] = useState("");
 
   const onSubmit = (e) => {
     e.preventDefault();
     if (text.trim()) {
       onCreate(text);
     }
-    setText('');
+    setText("");
     setOpen(false);
   };
 
@@ -30,7 +30,7 @@ function TodoCreate({ onCreate }) {
         </div>
       )}
       <button
-        className={open ? 'circle-button button-open' : 'circle-button'}
+        className={open ? "circle-button button-open" : "circle-button"}
         onClick={() => setOpen(!open)}
       >
         <MdAdd />

--- a/src/components/TodoHead/TodoHead.scss
+++ b/src/components/TodoHead/TodoHead.scss
@@ -14,10 +14,16 @@
     color: #868e96;
     font-size: 21px;
   }
+  .info-bar {
+    margin-top: 40px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
   .todos-left {
     color: #20c997;
     font-size: 18px;
-    margin-top: 40px;
     font-weight: bold;
   }
 }

--- a/src/components/TodoHead/index.js
+++ b/src/components/TodoHead/index.js
@@ -1,3 +1,4 @@
+import { signOut } from "../../api/auth";
 import "./TodoHead.scss";
 
 function TodoHead({ todos }) {
@@ -10,19 +11,13 @@ function TodoHead({ todos }) {
   });
   const dayName = today.toLocaleDateString("ko-KR", { weekday: "long" });
 
-  const onClickSignOut = () => {
-    // TODO: 로그아웃 로직 작성
-    window.sessionStorage.removeItem('isAuthenticated');
-    window.location.reload();
-  }
-
   return (
     <div className="head-container">
       <h1>{dateString}</h1>
       <div className="day">{dayName}</div>
       <div className="info-bar">
         <div className="todos-left">할 일 {undoneTodos.length}개 남음</div>
-        <div onClick={onClickSignOut}>로그아웃</div>
+        <div onClick={signOut}>로그아웃</div>
       </div>
     </div>
   );

--- a/src/components/TodoHead/index.js
+++ b/src/components/TodoHead/index.js
@@ -1,14 +1,14 @@
-import './TodoHead.scss';
+import "./TodoHead.scss";
 
 function TodoHead({ todos }) {
   const undoneTodos = todos.filter((todo) => !todo.done);
   const today = new Date();
-  const dateString = today.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
+  const dateString = today.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
   });
-  const dayName = today.toLocaleDateString('ko-KR', { weekday: 'long' });
+  const dayName = today.toLocaleDateString("ko-KR", { weekday: "long" });
 
   return (
     <div className="head-container">

--- a/src/components/TodoHead/index.js
+++ b/src/components/TodoHead/index.js
@@ -10,11 +10,20 @@ function TodoHead({ todos }) {
   });
   const dayName = today.toLocaleDateString("ko-KR", { weekday: "long" });
 
+  const onClickSignOut = () => {
+    // TODO: 로그아웃 로직 작성
+    window.sessionStorage.removeItem('isAuthenticated');
+    window.location.reload();
+  }
+
   return (
     <div className="head-container">
       <h1>{dateString}</h1>
       <div className="day">{dayName}</div>
-      <div className="todos-left">할 일 {undoneTodos.length}개 남음</div>
+      <div className="info-bar">
+        <div className="todos-left">할 일 {undoneTodos.length}개 남음</div>
+        <div onClick={onClickSignOut}>로그아웃</div>
+      </div>
     </div>
   );
 }

--- a/src/components/TodoItem/TodoItem.scss
+++ b/src/components/TodoItem/TodoItem.scss
@@ -15,7 +15,7 @@
   color: #ced4da;
 }
 
-.remove-icon {
+.edit-icon, .remove-icon {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { MdDone, MdDelete } from 'react-icons/md';
+import { MdDone, MdDelete, MdEdit } from 'react-icons/md';
 import './TodoItem.scss';
 
 function TodoItem({ todo, onToggle, onRemove }) {

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useState } from "react";
 //editIcon 추가
-import { MdDone, MdDelete, MdEdit } from 'react-icons/md';
-import './TodoItem.scss';
+import { MdDone, MdDelete, MdEdit } from "react-icons/md";
+import "./TodoItem.scss";
 
 function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
   const { id, text, done } = todo;
@@ -30,12 +30,12 @@ function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
       onMouseLeave={() => setIsIconVisible(false)}
     >
       <div
-        className={done ? 'check-circle circle-done' : 'check-circle'}
+        className={done ? "check-circle circle-done" : "check-circle"}
         onClick={() => onToggle(id)}
       >
         {done && <MdDone />}
       </div>
-      <div className={done ? 'text text-done' : 'text'}>
+      <div className={done ? "text text-done" : "text"}>
         {isTodoEditable ? (
           <form onSubmit={onSubmitTextUpdatedTodo}>
             <input value={todoText} onChange={onChangeText} />

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -26,7 +26,7 @@ function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
   return (
     <div
       className="item-block"
-      onMouseOver={() => setIsIconVisible(true)}
+      onMouseEnter={() => setIsIconVisible(true)}
       onMouseLeave={() => setIsIconVisible(false)}
     >
       <div

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -38,7 +38,7 @@ function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
       <div className={done ? 'text text-done' : 'text'}>
         {isTodoEditable ? (
           <form onSubmit={onSubmitTextUpdatedTodo}>
-            <input defaultValue={text} onChange={onChangeText} />
+            <input value={todoText} onChange={onChangeText} />
           </form>
         ) : (
           text

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+//editIcon 추가
 import { MdDone, MdDelete, MdEdit } from 'react-icons/md';
 import './TodoItem.scss';
 
@@ -6,8 +7,13 @@ function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
   const { id, text, done } = todo;
   //todo text 수정 위한 editIcon 추가되면서 isRemoveIconVisible의 변수명을 아래와 같이 바꿈
   const [isIconVisible, setIsIconVisible] = useState(false);
+
+  //edit icon 클릭시 div -> input으로 변경
   const [isTodoEditable, setIsTodoEditable] = useState(false);
+  //todo text
   const [todoText, setTodoText] = useState(text);
+
+  // input change 및 submit
   const onChangeText = (e) => {
     setTodoText(e.target.value);
   };

--- a/src/components/TodoItem/index.js
+++ b/src/components/TodoItem/index.js
@@ -2,15 +2,26 @@ import { useState } from 'react';
 import { MdDone, MdDelete, MdEdit } from 'react-icons/md';
 import './TodoItem.scss';
 
-function TodoItem({ todo, onToggle, onRemove }) {
+function TodoItem({ todo, onToggle, onUpdate, onRemove }) {
   const { id, text, done } = todo;
-  const [isRemoveIconVisible, setIsRemoveIconVisible] = useState(false);
+  //todo text 수정 위한 editIcon 추가되면서 isRemoveIconVisible의 변수명을 아래와 같이 바꿈
+  const [isIconVisible, setIsIconVisible] = useState(false);
+  const [isTodoEditable, setIsTodoEditable] = useState(false);
+  const [todoText, setTodoText] = useState(text);
+  const onChangeText = (e) => {
+    setTodoText(e.target.value);
+  };
+  const onSubmitTextUpdatedTodo = (e) => {
+    e.preventDefault();
+    onUpdate(id, todoText);
+    setIsTodoEditable(false);
+  };
 
   return (
     <div
       className="item-block"
-      onMouseOver={() => setIsRemoveIconVisible(true)}
-      onMouseLeave={() => setIsRemoveIconVisible(false)}
+      onMouseOver={() => setIsIconVisible(true)}
+      onMouseLeave={() => setIsIconVisible(false)}
     >
       <div
         className={done ? 'check-circle circle-done' : 'check-circle'}
@@ -18,10 +29,25 @@ function TodoItem({ todo, onToggle, onRemove }) {
       >
         {done && <MdDone />}
       </div>
-      <div className={done ? 'text text-done' : 'text'}>{text}</div>
+      <div className={done ? 'text text-done' : 'text'}>
+        {isTodoEditable ? (
+          <form onSubmit={onSubmitTextUpdatedTodo}>
+            <input defaultValue={text} onChange={onChangeText} />
+          </form>
+        ) : (
+          text
+        )}
+      </div>
+      <div
+        className="edit-icon"
+        style={{ display: isIconVisible ? "initial" : "none" }}
+        onClick={() => setIsTodoEditable(true)}
+      >
+        <MdEdit />
+      </div>
       <div
         className="remove-icon"
-        style={{ display: isRemoveIconVisible ? 'initial' : 'none' }}
+        style={{ display: isIconVisible ? "initial" : "none" }}
         onClick={() => onRemove(id)}
       >
         <MdDelete />

--- a/src/components/TodoList/index.js
+++ b/src/components/TodoList/index.js
@@ -1,7 +1,7 @@
 import './TodoList.scss';
 import TodoItem from '../TodoItem';
 
-function TodoList({ todos, onToggle, onRemove }) {
+function TodoList({ todos, onToggle, onUpdate, onRemove }) {
   return (
     <div className="list-container">
       {todos.map((todo) => (
@@ -9,6 +9,7 @@ function TodoList({ todos, onToggle, onRemove }) {
           key={todo.id}
           todo={todo}
           onToggle={onToggle}
+          onUpdate = {onUpdate}
           onRemove={onRemove}
         />
       ))}

--- a/src/components/TodoList/index.js
+++ b/src/components/TodoList/index.js
@@ -1,5 +1,5 @@
-import './TodoList.scss';
-import TodoItem from '../TodoItem';
+import "./TodoList.scss";
+import TodoItem from "../TodoItem";
 
 function TodoList({ todos, onToggle, onUpdate, onRemove }) {
   return (
@@ -9,7 +9,7 @@ function TodoList({ todos, onToggle, onUpdate, onRemove }) {
           key={todo.id}
           todo={todo}
           onToggle={onToggle}
-          onUpdate = {onUpdate}
+          onUpdate={onUpdate}
           onRemove={onRemove}
         />
       ))}

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -24,6 +24,20 @@ function TodoTemplate() {
       })
       .catch((err) => console.log(err));
   };
+
+  const onUpdate = (id, text) => {
+    const newText = { text: text };
+    axios
+      .patch(`/api/todos/${id}/`, newText)
+      .then(() => {
+        const newTodos = todos.map((todo) =>
+          todo.id === id ? { ...todo, text: text } : todo
+        );
+        setTodos(newTodos);
+      })
+      .catch((err) => console.log(err));
+  };
+
   const onRemove = (id) => {
     const newTodos = todos.filter((todo) => todo.id !== id);
     setTodos(newTodos);

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -34,9 +34,8 @@ function TodoTemplate() {
 
   //todo update(2주차 심화과제)
   const onUpdate = (id, text) => {
-    const newText = { text: text };
     axios
-      .patch(`/api/todos/${id}/`, newText)
+      .patch(`/api/todos/${id}/`, {text})
       .then(() => {
         const newTodos = todos.map((todo) =>
           todo.id === id ? { ...todo, text: text } : todo

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -39,8 +39,13 @@ function TodoTemplate() {
   };
 
   const onRemove = (id) => {
-    const newTodos = todos.filter((todo) => todo.id !== id);
-    setTodos(newTodos);
+    axios
+      .delete(`/api/todos/${id}/`)
+      .then(() => {
+        const newTodos = todos.filter((todo) => todo.id !== id);
+        setTodos(newTodos);
+      })
+      .catch((err) => console.log(err));
   };
   const onCreate = (text) => {
     const newTodos = [...todos, { id: nextId, text, done: false }];

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -11,9 +11,12 @@ function TodoTemplate() {
 
   //todos get
   useEffect(() => {
-    axios.get("/api/todos").then((res) => {
-      setTodos(res.data.todos);
-    });
+    axios
+      .get("/api/todos")
+      .then((res) => {
+        setTodos(res.data.todos);
+      })
+      .catch((err) => console.log(err));
   }, []);
 
   //todo toggle

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -6,13 +6,17 @@ import TodoCreate from '../TodoCreate';
 import axios from "axios";
 
 function TodoTemplate() {
+  //2주차 dummy data 제거
   const [todos, setTodos] = useState([]);
+
+  //todos get
   useEffect(() => {
     axios.get("/api/todos").then((res) => {
       setTodos(res.data.todos);
     });
   }, []);
 
+  //todo toggle
   const onToggle = (id) => {
     axios
       .patch(`/api/todos/${id}/check/`)
@@ -25,6 +29,7 @@ function TodoTemplate() {
       .catch((err) => console.log(err));
   };
 
+  //todo update(2주차 심화과제)
   const onUpdate = (id, text) => {
     const newText = { text: text };
     axios
@@ -38,6 +43,7 @@ function TodoTemplate() {
       .catch((err) => console.log(err));
   };
 
+  //todo delete
   const onRemove = (id) => {
     axios
       .delete(`/api/todos/${id}/`)
@@ -47,6 +53,8 @@ function TodoTemplate() {
       })
       .catch((err) => console.log(err));
   };
+
+  //todo post
   const onCreate = (text) => {
     const newTodo = { text };
     axios

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -1,14 +1,18 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './TodoTemplate.scss';
 import TodoHead from '../TodoHead';
 import TodoList from '../TodoList';
 import TodoCreate from '../TodoCreate';
+import axios from "axios";
 
 function TodoTemplate() {
-  const [nextId, setNextId] = useState(2);
-  const [todos, setTodos] = useState([
-    { id: 1, text: '세미나 잘 듣기', done: false },
-  ]);
+  const [todos, setTodos] = useState([]);
+  useEffect(() => {
+    axios.get("/api/todos").then((res) => {
+      setTodos(res.data.todos);
+    });
+  }, []);
+
   const onToggle = (id) => {
     const newTodos = todos.map((todo) =>
       todo.id === id ? { ...todo, done: !todo.done } : todo

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
-import './TodoTemplate.scss';
-import TodoHead from '../TodoHead';
-import TodoList from '../TodoList';
-import TodoCreate from '../TodoCreate';
+import { useState, useEffect } from "react";
+import "./TodoTemplate.scss";
+import TodoHead from "../TodoHead";
+import TodoList from "../TodoList";
+import TodoCreate from "../TodoCreate";
 import axios from "axios";
 
 function TodoTemplate() {

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -48,15 +48,24 @@ function TodoTemplate() {
       .catch((err) => console.log(err));
   };
   const onCreate = (text) => {
-    const newTodos = [...todos, { id: nextId, text, done: false }];
-    setTodos(newTodos);
-    setNextId(nextId + 1);
+    const newTodo = { text };
+    axios
+      .post("/api/todos/create/", newTodo)
+      .then((res) => {
+        setTodos([...todos, res.data.todo]);
+      })
+      .catch((err) => console.log(err));
   };
 
   return (
     <div className="template-container">
       <TodoHead todos={todos} />
-      <TodoList todos={todos} onToggle={onToggle} onRemove={onRemove} />
+      <TodoList
+        todos={todos}
+        onToggle={onToggle}
+        onUpdate={onUpdate}
+        onRemove={onRemove}
+      />
       <TodoCreate onCreate={onCreate} />
     </div>
   );

--- a/src/components/TodoTemplate/index.js
+++ b/src/components/TodoTemplate/index.js
@@ -14,10 +14,15 @@ function TodoTemplate() {
   }, []);
 
   const onToggle = (id) => {
-    const newTodos = todos.map((todo) =>
-      todo.id === id ? { ...todo, done: !todo.done } : todo
-    );
-    setTodos(newTodos);
+    axios
+      .patch(`/api/todos/${id}/check/`)
+      .then(() => {
+        const newTodos = todos.map((todo) =>
+          todo.id === id ? { ...todo, done: !todo.done } : todo
+        );
+        setTodos(newTodos);
+      })
+      .catch((err) => console.log(err));
   };
   const onRemove = (id) => {
     const newTodos = todos.filter((todo) => todo.id !== id);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## UI 작업
- 로그인, 회원가입, 로그아웃 기능 추가
- 서버와 관련되어 API를 호출하거나 API 응답을 처리하는 코드는 넣지 않았습니다. 따라서 로그인 여부는 세션 스토리지의 `isAuthenticated` 값을 사용하여 체크하는 것으로 임시 처리 되어 있습니다.
- 현재 아무 값이나 입력만 한다면 로그인이 가능한 상태입니다.

- 추가된 기능 모두 같은 템플릿에서 진행할 수 있게 코드 짰는데 이렇게 작성한다면 App.js 단에서 div 넣고 className `template-container` 넣어줘도 될 것 같습니다.


## API 연동
- 로그인, 회원가입, 로그아웃 API 연동

- 각 기능이 실패했을 때의 처리는 따로 하지 않았습니다. 필요한 것이 있다면 말씀해주세요.
- 현재 서버 코드 단에서 todo 객체의 CRUD와 관련하여 4주차에 추가되는 인증 작업이 반영되지 않았습니다. 서버 코드를 수정한 이후 프론트 코드도 추가 수정이 필요할 수 있습니다. @lynn0506 
- 프론트단에서 jwt로 인증 플로우 구축하는 걸 처음해봤습니다. 일단 구글링해서 코드 써넣긴 했는데 염려되는 지점들이 있습니다. 이 점들 유의해서 봐주시면 감사하겠습니다
  - [이 아티클](https://velog.io/@yaytomato/%ED%94%84%EB%A1%A0%ED%8A%B8%EC%97%90%EC%84%9C-%EC%95%88%EC%A0%84%ED%95%98%EA%B2%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)을 참고하였습니다.
  - 위 아티클에 따라 토큰을 브라우저 스토리지에 저장하지 않으려했고, access token을 앱 내 지역 변수로 사용했습니다. (axios 디폴트 값)
  - 서버에서는 jwt 토큰을 [drf simple-jwt](https://github.com/jazzband/djangorestframework-simplejwt/blob/master/docs/index.rst)을 활용해 구현했습니다. 이 라이브러리에서는 refresh 토큰 업데이트를 위해 클라이언트가 payload에 refresh token의 값을 넣어줘야 합니다. 하지만 위 아티클에서는 서버에서 refresh token을 관리하고 쿠키에 넣어준다는 가정을 하고 있었어요. 그래서 우선 refresh token은 세션 스토리지에서 관리하도록 구현했습니다.
  - 이렇게 처리하고 보니 **'조금 번잡한 감이 있는데 보안은 신경쓰지 말고 세션 스토리지에서 다 관리하자' vs 'jwt를 사용해보는데 기왕 보안에 관해서 조금 더 생각해볼 수 있게 하자'로 고민이 됩니다. 이 점 관련해서 의견을 듣고 싶어요**
- 급하게 쓰냐고 리팩토링은 거의 하지 않았습니다... 테스트도 제일 간단한 플로우만 했어요. 똥 코드도 지적해주시면 감사하겠습니다...! 🙏